### PR TITLE
Add `unprotectEff`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # resourcet-effectful-1.0.1.0 (2023-??-??)
-* Add `allocateEff`, `allocateEff_`, `registerEff`, `releaseEff`.
+* Add `allocateEff`, `allocateEff_`, `registerEff`, `releaseEff`,
+  `unprotectEff`.
 * Re-export `ReleaseKey` and `ResourceCleanupException`.
 
 # resourcet-effectful-1.0.0.0 (2022-07-14)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # resourcet-effectful-1.0.1.0 (2023-??-??)
-* Add `allocateEff`, `allocateEff_` and `registerEff`.
+* Add `allocateEff`, `allocateEff_`, `registerEff`, `releaseEff` and
+  `unprotectEff`.
+* Re-export `ReleaseKey` and `ResourceCleanupException`.
 
 # resourcet-effectful-1.0.0.0 (2022-07-14)
 * Initial release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # resourcet-effectful-1.0.1.0 (2023-??-??)
-* Add `allocateEff`, `allocateEff_`, `registerEff`, `releaseEff` and
-  `unprotectEff`.
+* Add `allocateEff`, `allocateEff_`, `registerEff`, `releaseEff`.
 * Re-export `ReleaseKey` and `ResourceCleanupException`.
 
 # resourcet-effectful-1.0.0.0 (2022-07-14)

--- a/src/Effectful/Resource.hs
+++ b/src/Effectful/Resource.hs
@@ -13,7 +13,6 @@ module Effectful.Resource
   , allocateEff_
   , registerEff
   , releaseEff
-  , unprotectEff
   , R.allocate
   , R.allocate_
   , R.register
@@ -109,18 +108,6 @@ registerEff release = do
 -- | A variant of 'R.release' adjusted to work in the 'Eff' monad.
 releaseEff :: Resource :> es => R.ReleaseKey -> Eff es ()
 releaseEff = unsafeEff_ . R.release
-
--- | A variant of 'R.unprotect' adjusted to work in the 'Eff' monad.
---
--- /Note:/ if the resource was acquired using 'allocateEff', 'allocateEff_' or
--- 'registerEff' then the @release@ action returned will run in a clone of the
--- environment it was registered in, so the effect row @es'@ will be ignored.
--- Please see the documentation of the aforementioned functions.
-unprotectEff
-  :: (Resource :> es, Resource :> es')
-  => R.ReleaseKey
-  -> Eff es (Maybe (Eff es' ()))
-unprotectEff = unsafeEff_ . fmap (fmap unsafeEff_) . R.unprotect
 
 ----------------------------------------
 -- Internal state

--- a/src/Effectful/Resource.hs
+++ b/src/Effectful/Resource.hs
@@ -13,6 +13,7 @@ module Effectful.Resource
   , allocateEff_
   , registerEff
   , releaseEff
+  , unprotectEff
   , R.allocate
   , R.allocate_
   , R.register
@@ -108,6 +109,18 @@ registerEff release = do
 -- | A variant of 'R.release' adjusted to work in the 'Eff' monad.
 releaseEff :: Resource :> es => R.ReleaseKey -> Eff es ()
 releaseEff = unsafeEff_ . R.release
+
+-- | A variant of 'R.unprotect' adjusted to work in the 'Eff' monad.
+--
+-- /Note:/ if the resource was acquired using 'allocateEff', 'allocateEff_' or
+-- 'registerEff' then the @release@ action returned will run in a clone of the
+-- environment it was registered in, so the effect row @es'@ will be ignored.
+-- Please see the documentation of the aforementioned functions.
+unprotectEff
+  :: (Resource :> es, Resource :> es')
+  => R.ReleaseKey
+  -> Eff es (Maybe (Eff es' ()))
+unprotectEff = unsafeEff_ . fmap (fmap unsafeEff_) . R.unprotect
 
 ----------------------------------------
 -- Internal state

--- a/src/Effectful/Resource.hs
+++ b/src/Effectful/Resource.hs
@@ -112,9 +112,14 @@ releaseEff = unsafeEff_ . R.release
 
 -- | A variant of 'R.unprotect' adjusted to work in the 'Eff' monad.
 --
--- /Note:/ the @release@ action returned will run a clone of the environment it
--- was registered in, so the effect row @es'@ will be ignored.
-unprotectEff :: (Resource :> es, Resource :> es') => R.ReleaseKey -> Eff es (Maybe (Eff es' ()))
+-- /Note:/ if the resource was acquired using 'allocateEff', 'allocateEff_' or
+-- 'registerEff' then the @release@ action returned will run in a clone of the
+-- environment it was registered in, so the effect row @es'@ will be ignored.
+-- Please see the documentation of the aforementioned functions.
+unprotectEff
+  :: (Resource :> es, Resource :> es')
+  => R.ReleaseKey
+  -> Eff es (Maybe (Eff es' ()))
 unprotectEff = unsafeEff_ . fmap (fmap unsafeEff_) . R.unprotect
 
 ----------------------------------------


### PR DESCRIPTION
This is a follow-up PR of https://github.com/haskell-effectful/resourcet-effectful/pull/5, which adds an effectul version of `unprotectEff`. Since it has not been clear what type the returned action of that function should be it was agreed on to split the original PR; See https://github.com/haskell-effectful/resourcet-effectful/pull/5#discussion_r1332127839 and the following comments.